### PR TITLE
ci: enforce dependency review gate on pull requests

### DIFF
--- a/.github/workflows/dependency-review-pr.yml
+++ b/.github/workflows/dependency-review-pr.yml
@@ -10,5 +10,10 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
-      - name: Dependency review placeholder
-        run: echo "Dependency review workflow is enabled for pull requests."
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high


### PR DESCRIPTION
## Summary
- replace placeholder dependency-review job with `actions/dependency-review-action@v4`
- fail PR checks when dependency findings are `high` severity or above
- keep workflow scoped to pull requests

## Validation
- local YAML parse check passed for `.github/workflows/dependency-review-pr.yml`

Closes #48

## Summary by Sourcery

CI:
- Replace the placeholder dependency review job with the official dependency-review GitHub Action and configure it to run on pull requests, failing when vulnerabilities of high severity or above are detected.